### PR TITLE
Improve mobile ui inspired by chatgpt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "multi-ai-playground",
-  "version": "0.1.0",
+  "name": "multi-ai-chat-platform",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "multi-ai-playground",
-      "version": "0.1.0",
+      "name": "multi-ai-chat-platform",
+      "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/src/components/Chat/ChatColumn.jsx
+++ b/src/components/Chat/ChatColumn.jsx
@@ -13,7 +13,7 @@ export default function ChatColumn({ title, messages }) {
     }, [messages?.length])
     return (
         <div className="card h-full flex flex-col min-h-0">
-            <div className="text-sm font-semibold mb-2">{title}</div>
+            <div className="text-sm font-semibold mb-2 sticky top-0 z-10 bg-white/85 backdrop-blur rounded-xl p-1">{title}</div>
             <div
                 ref={scrollerRef}
                 className="flex-1 overflow-y-auto scroll-smooth overscroll-contain pr-2"
@@ -32,5 +32,3 @@ export default function ChatColumn({ title, messages }) {
         </div>
     )
 }
-
-

--- a/src/components/InputBar.jsx
+++ b/src/components/InputBar.jsx
@@ -3,10 +3,10 @@ import React, { useState } from 'react'
 export default function InputBar({ onSend, loading }) {
     const [value, setValue] = useState('')
     return (
-        <div className="p-4 border-t bg-white sticky bottom-0 flex-none">
-            <div className="max-w-4xl mx-auto flex gap-2">
+        <div className="p-3 md:p-4 border-t bg-white sticky bottom-0 flex-none">
+            <div className="max-w-3xl mx-auto flex gap-2 items-end">
                 <input
-                    className="flex-1 rounded-xl border px-3 py-2"
+                    className="flex-1 rounded-xl border px-3 py-3 text-[16px]"
                     placeholder="Type a message..."
                     value={value}
                     onChange={(e) => setValue(e.target.value)}
@@ -18,7 +18,7 @@ export default function InputBar({ onSend, loading }) {
                     }}
                 />
                 <button
-                    className="px-4 py-2 rounded-lg bg-blue-600 text-white disabled:opacity-50"
+                    className="px-4 py-3 rounded-lg bg-blue-600 text-white disabled:opacity-50"
                     disabled={loading}
                     onClick={() => onSend?.(value, () => setValue(''))}
                 >

--- a/src/components/Layout/Sidebar.jsx
+++ b/src/components/Layout/Sidebar.jsx
@@ -5,7 +5,7 @@ import { useChatContext } from '../../context/ChatContext.jsx'
 import { useApiKeys } from '../../context/ApiKeyContext.jsx'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
-export default function Sidebar() {
+export default function Sidebar({ mobile = false, className = '' }) {
     const { chats, activeChatId, setActiveChatId, newChat, deleteChat } = useChatContext()
     const navigate = useNavigate()
     const location = useLocation()
@@ -21,7 +21,7 @@ export default function Sidebar() {
             initial={{ x: -20, opacity: 0 }}
             animate={{ x: 0, opacity: 1 }}
             transition={{ duration: 0.25 }}
-            className="w-72 shrink-0 h-screen sticky top-0 bg-gray-900 text-white flex flex-col"
+            className={`${mobile ? 'block' : 'hidden md:flex'} w-72 shrink-0 h-screen bg-gray-900 text-white flex-col ${mobile ? '' : 'sticky top-0'} ${className}`}
         >
             <div className="p-4 flex items-center justify-between">
                 <div className="font-semibold">Multi AI</div>

--- a/src/pages/ApiSetup.jsx
+++ b/src/pages/ApiSetup.jsx
@@ -62,7 +62,7 @@ export default function ApiSetup() {
     }
 
     return (
-        <div className="min-h-screen flex items-center justify-center bg-neutral-100">
+        <div className="min-h-screen flex items-center justify-center bg-neutral-100 p-3">
             <div className="card max-w-xl w-full">
                 {/* User Info Header */}
                 {user && (
@@ -168,5 +168,3 @@ export default function ApiSetup() {
         </div>
     )
 }
-
-

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -9,6 +9,7 @@ import { GeminiAdapter } from '../adapters/GeminiAdapter.js'
 import { ClaudeAdapter } from '../adapters/ClaudeAdapter.js'
 import { ZhipuAdapter } from '../adapters/ZhipuAdapter.js'
 import { CustomAdapter } from '../adapters/CustomAdapter.js'
+import { Menu } from 'lucide-react'
 
 export default function Chat() {
     const { activeChat, appendMessage } = useChatContext()
@@ -63,13 +64,39 @@ export default function Chat() {
         }
     }
 
+    const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+
     return (
         <div className="flex h-screen overflow-hidden">
-            <Sidebar />
+            {/* Desktop sidebar */}
+            <Sidebar mobile={false} />
+
+            {/* Mobile slide-over */}
+            {mobileMenuOpen && (
+                <div className="fixed inset-0 z-40 flex md:hidden" role="dialog" aria-modal="true">
+                    <div className="fixed inset-0 bg-black/40" onClick={() => setMobileMenuOpen(false)}></div>
+                    <div className="relative ml-0 h-full w-72 bg-gray-900 text-white shadow-xl">
+                        <Sidebar mobile className="h-full" />
+                    </div>
+                </div>
+            )}
+
             <div className="flex-1 flex flex-col min-h-0">
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 flex-1 overflow-y-auto">
-                    {providers.filter(p => p.enabled).map((p, idx, arr) => (
-                        <div key={p.id} className="h-full flex flex-col p-4">
+                {/* Mobile top bar */}
+                <div className="md:hidden sticky top-0 z-30 bg-white border-b">
+                    <div className="flex items-center justify-between px-3 py-2">
+                        <button className="inline-flex items-center gap-2 rounded-md px-2 py-1 border" onClick={() => setMobileMenuOpen(true)}>
+                            <Menu size={18} />
+                            Menu
+                        </button>
+                        <div className="text-sm text-neutral-600">Multi AI Playground</div>
+                        <div className="w-[64px]" />
+                    </div>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 flex-1 overflow-y-auto p-3 md:p-4">
+                    {providers.filter(p => p.enabled).map((p) => (
+                        <div key={p.id} className="h-full flex flex-col p-2 md:p-4">
                             <ChatColumn title={p.name} messages={perProviderMessages[p.id] || []} />
                         </div>
                     ))}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -52,4 +52,7 @@ body {
 	@apply rounded-2xl shadow-lg p-4 bg-white dark:bg-neutral-900;
 }
 
-
+/* Mobile-friendly tweaks */
+@media (max-width: 768px) {
+	.card { @apply p-3 rounded-xl; }
+}


### PR DESCRIPTION
Implement a mobile-first UI inspired by ChatGPT to improve the chat application's usability on small screens.

The previous UI was not optimized for mobile devices. This PR introduces a responsive design that includes a hidden sidebar with a slide-over drawer on mobile, a sticky top bar, and adjusted layout/spacing for better readability and interaction on smaller screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbe8a31a-703d-49eb-97d0-0070b230eff9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbe8a31a-703d-49eb-97d0-0070b230eff9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

